### PR TITLE
Update Guix-Guide.md

### DIFF
--- a/Guix-Guide.md
+++ b/Guix-Guide.md
@@ -172,11 +172,11 @@ If you don't set it, it will build Bitcoin Core for all supported targets (inclu
 The exact targets supported vary for each release, you can find the specific list for 24.0.1 [in this link].
 
 If you skipped the MacOS section it is important to define the `HOSTS` variable without any Apple targets, otherwise Guix won't start.
-In this example we'll tell Guix to only build binaries for Linux x86_64, Linux ARM64 (e.g. for a Raspberry Pi 4) and Apple Silicon (since we actually went through the pain of preparing the Xcode SDK).
+In this example we'll tell Guix to only build binaries for Linux x86_64, Linux ARM64 (e.g. for a Raspberry Pi 4).
 This will also make the build run faster than if it had to build all 9 targets.
 
 ```sh
-$ export HOSTS="x86_64-linux-gnu aarch64-linux-gnu arm64-apple-darwin"
+$ export HOSTS="x86_64-linux-gnu aarch64-linux-gnu"
 ```
 
 ...and we're ready to buidl.


### PR DESCRIPTION
Hey, I am taking out Apple Silicon as it does not goes well without the Apple SDK.

This compilates the non-MacOS versions and improves the overall time of the process.

Failure below:
```
root@testing:~/bitcoin# ./contrib/guix/guix-build
macOS SDK does not exist at '/root/bitcoin/depends/SDKs/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers', please place the extracted, untarred SDK there to perform darwin builds, or define SDK_PATH environment variable. Exiting...
root@testing:~/bitcoin#
```

--
Using fresh Ubuntu 22.04.


KR,
Federico.